### PR TITLE
Use platform instead of browser and allow CLI

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE `execution` (
   `duration` int(11) NOT NULL,
   `version` varchar(20) NOT NULL,
   `campaign` varchar(50) NOT NULL DEFAULT 'functional',
-  `browser` varchar(50) NOT NULL DEFAULT 'chromium',
+  `platform` varchar(50) NOT NULL DEFAULT 'chromium',
   `suites` int(11) DEFAULT NULL,
   `tests` int(11) DEFAULT NULL,
   `skipped` int(11) DEFAULT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE `execution` (
   `equal_since_last` int(11) DEFAULT NULL,
   `insertion_start_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `insertion_end_date` timestamp NULL DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -35,14 +35,14 @@ CREATE TABLE `settings` (
   `id` int(11) NOT NULL,
   `name` varchar(30) NOT NULL,
   `value` text NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 --
 -- Dumping data for table `settings`
 --
 
 INSERT INTO `settings` (`id`, `name`, `value`) VALUES
-(1, 'version', '2');
+(1, 'version', '3');
 
 -- --------------------------------------------------------
 
@@ -70,7 +70,7 @@ CREATE TABLE `suite` (
   `hasTests` int(11) DEFAULT NULL,
   `parent_id` int(11) DEFAULT NULL,
   `insertion_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -90,7 +90,7 @@ CREATE TABLE `test` (
   `stack_trace` text,
   `diff` text,
   `insertion_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 --
 -- Indexes for table `execution`

--- a/src/Upgrade/versions/3.php
+++ b/src/Upgrade/versions/3.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager;
+
+function update3() {
+    echo "\n Upgrading to version 3...\n";
+    try {
+
+        $tables = ['execution', 'settings', 'suite', 'test'];
+        foreach ($tables as $table) {
+            // convert tables to utf8mb4
+            Manager::statement('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET utf8mb4;');
+        }
+        //change "browser" to a more generic "platform" column
+        Manager::statement('ALTER TABLE `execution` CHANGE `browser` `platform` VARCHAR(50) NOT NULL DEFAULT \'chromium\';');
+
+        //update the version in database
+        Manager::table('settings')->where('name', '=', 'version')->update(['value' => 3]);
+    } catch (Exception $e) {
+        return false;
+    }
+    echo "Finished updating database\n\n";
+    return true;
+
+}
+
+return update3();

--- a/src/database.php
+++ b/src/database.php
@@ -9,8 +9,8 @@ $capsule->addConnection([
     'database'  => QANB_DB_NAME,
     'username'  => QANB_DB_USERNAME,
     'password'  => QANB_DB_PASSWORD,
-    'charset'   => 'utf8',
-    'collation' => 'utf8_unicode_ci',
+    'charset'   => 'utf8mb4',
+    'collation' => 'utf8mb4_0900_ai_ci',
     'prefix'    => '',
 ]);
 $capsule->setAsGlobal();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The current implementation was build around UI tests and was linked to a browser. In order to extend the possibility, this PR aims to replace "browser"-related data to a more generic term: "platform". It also allow the platform "cli" to be used.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Add a new report with the endpoint `/hook/add` and with the get parameter `platform=cli`. The endpoints `/reports` & `/report/{id}` should return the new key `platform` (as well as the `browser` kept for compatibility purpose) with the value `cli`.<br>You should also try to upgrade from version 2 to version 3 to see if the change of the DB structure is working.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
